### PR TITLE
Fix service to work correctly with Selenium API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,18 @@ Path where all logs from the Selenium server should be stored.
 Type: `String`
 
 ### seleniumArgs
-Array of arguments for the Selenium server, passed directly to `child_process.spawn`.
+Map of arguments for the Selenium server, passed directly to `Selenium.start()`.
 
-Type: `String[]`<br>
-Default: `[]`
+Type: `Object`
+
+Default: `{}`
+
+### seleniumInstallArgs
+Map of arguments for the Selenium server, passed directly to `Selenium.install()`.
+
+Type: `Object`
+
+Default: `{}`
 
 ----
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -8,16 +8,18 @@ const DEFAULT_LOG_FILENAME = 'selenium-standalone.txt'
 class SeleniumStandaloneLauncher {
     constructor () {
         this.seleniumLogs = null
+        this.seleniumArgs = {}
+        this.seleniumInstallArgs = {}
         this.logToStdout = false
-        this.opts = {}
     }
 
     onPrepare (config) {
-        this.opts.seleniumArgs = config.seleniumArgs || []
+        this.seleniumArgs = config.seleniumArgs || {}
+        this.seleniumInstallArgs = config.seleniumInstallArgs || {}
         this.seleniumLogs = config.seleniumLogs
         this.logToStdout = config.logToStdout
 
-        return new Promise((resolve, reject) => Selenium.start(this.opts, (err, process) => {
+        return this._installSeleniumDependencies(this.seleniumInstallArgs).then(() => new Promise((resolve, reject) => Selenium.start(this.seleniumArgs, (err, process) => {
             if (err) {
                 return reject(err)
             }
@@ -28,13 +30,23 @@ class SeleniumStandaloneLauncher {
             }
 
             resolve()
-        }))
+        })))
     }
 
     onComplete () {
         if (this.process) {
             this.process.kill()
         }
+    }
+
+    _installSeleniumDependencies (seleniumInstallArgs) {
+        return new Promise((resolve, reject) => Selenium.install(seleniumInstallArgs, (err) => {
+            if (err) {
+                return reject(err)
+            }
+
+            resolve()
+        }))
     }
 
     _redirectLogStream () {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "wdio-selenium-standalone-service",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "WebdriverIO service to start & stop Selenium Standalone",
   "main": "index.js",
   "scripts": {
-    "postinstall": "selenium-standalone install",
     "build": "grunt build",
     "prepublish": "npm prune && npm run build",
     "test": "wdio test/wdio.conf.js"

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -25,5 +25,11 @@ exports.config = {
     services: [
         require('../launcher')
     ],
-    seleniumLogs: './'
+    seleniumLogs: './',
+    seleniumArgs: {
+        version: "2.45.0"
+    },
+    seleniumInstallArgs: {
+        version: "2.45.0"
+    }
 }


### PR DESCRIPTION
- install selenium dependencies at runtime (this allows for better flexibility then attempting to install everything at postinstall)
- pass correct arguments to selenium.start (you never actually used seleniumArgs anywhere in the code)
