### PR TITLE
Move selenium-standalone to a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   },
   "homepage": "https://github.com/webdriverio/wdio-selenium-standalone-service#readme",
   "dependencies": {
-    "fs-extra": "^0.30.0"
-  },
-  "peerDependencies": {
+    "fs-extra": "^0.30.0",
     "selenium-standalone": "^5.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes issue #11. Tested locally in npm v2.14.20 (node 4.4.0) and npm v3.10.7(node 6.5.0). I used `npm link` to connect the module to a standard wdio project I had in place.
