### PR TITLE
upgrade selenium-standalone to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/webdriverio/wdio-selenium-standalone-service#readme",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "selenium-standalone": "^5.6.0"
+    "selenium-standalone": "^6.0.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
It is necessary to upgrade selenium-standalone to support the new version of firefox