### PR TITLE
: update selenium standalone to version 6.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/webdriverio/wdio-selenium-standalone-service#readme",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "selenium-standalone": "^6.3.0"
+    "selenium-standalone": "^6.5.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
This update is needed to resolve chrome to open in maximize mode
while runnig in headless mode.

This commit is dependent on below commit
https://github.com/vvo/selenium-standalone/pull/285

Once above commit gets merged selenium standalone would be updated
to have version 6.5.0 and will point to use chrome driver 2.30.