### PR TITLE
Detect port

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,12 @@ Type: `Object`
 
 Default: `{}`
 
-### Port Copying
-This service will automatically launch the standalone server on the port specified in your WebDriverIO configuration file when the `usePortInStandalone` flag is `true`. 
+### port
+This service will automatically launch the standalone server on the port specified in your WebDriverIO configuration file. 
 
 For example:
 ```js
 port: 4441,
-usePortInStandalone: true,
 seleniumArgs: {
   javaArgs: [
     "-Xmx1024m"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Type: `Object`
 
 Default: `{}`
 
+### Port Copying
+This service will automatically launch the standalone server on the port specified in your WebDriverIO configuration file when the `usePortInStandalone` flag is `true`. 
+
+For example:
+```js
+port: 4441,
+usePortInStandalone: true,
+seleniumArgs: {
+  javaArgs: [
+    "-Xmx1024m"
+  ]
+}
+```
+This is useful for specifying custom ports on the command line when running tests, allowing multiple instances of the standalone server to run concurrently.
+
+
 ----
 
 For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -45,7 +45,7 @@ class SeleniumStandaloneLauncher {
             if (this.seleniumArgs.seleniumArgs === undefined) {
                 this.seleniumArgs.seleniumArgs = []
             }
-            if (!this.seleniumArgs.seleniumArgs.indexOf('-port') >= 0) {
+            if (this.seleniumArgs.seleniumArgs.indexOf('-port') < 0) {
                 this.seleniumArgs.seleniumArgs.push('-port', config.port)
             }
         }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -19,7 +19,7 @@ class SeleniumStandaloneLauncher {
         this.logToStdout = config.logToStdout
 
         if (!this.seleniumArgs.port && config.port) {
-            this.seleniumArgs.seleniumArgs = ['-port', config.port];
+            this.seleniumArgs.seleniumArgs = ['-port', config.port]
         }
 
         return this._installSeleniumDependencies(this.seleniumInstallArgs).then(() => new Promise((resolve, reject) => Selenium.start(this.seleniumArgs, (err, process) => {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -41,7 +41,7 @@ class SeleniumStandaloneLauncher {
         this.seleniumLogs = config.seleniumLogs
         this.logToStdout = config.logToStdout
 
-        if (config.port && config.usePortInStandalone) {
+        if (config.port) {
             if (this.seleniumArgs.seleniumArgs === undefined) {
                 this.seleniumArgs.seleniumArgs = []
             }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -45,7 +45,7 @@ class SeleniumStandaloneLauncher {
             if (this.seleniumArgs.seleniumArgs === undefined) {
                 this.seleniumArgs.seleniumArgs = []
             }
-            if (!this.seleniumArgs.seleniumArgs.includes('-port')) {
+            if (!this.seleniumArgs.seleniumArgs.indexOf('-port') >= 0) {
                 this.seleniumArgs.seleniumArgs.push('-port', config.port)
             }
         }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -18,6 +18,10 @@ class SeleniumStandaloneLauncher {
         this.seleniumLogs = config.seleniumLogs
         this.logToStdout = config.logToStdout
 
+        if (!this.seleniumArgs.port && config.port) {
+            this.seleniumArgs.seleniumArgs = ['-port', config.port];
+        }
+
         return this._installSeleniumDependencies(this.seleniumInstallArgs).then(() => new Promise((resolve, reject) => Selenium.start(this.seleniumArgs, (err, process) => {
             if (err) {
                 return reject(err)

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -18,7 +18,7 @@ class SeleniumStandaloneLauncher {
         this.seleniumLogs = config.seleniumLogs
         this.logToStdout = config.logToStdout
 
-        if (!this.seleniumArgs.port && config.port) {
+        if (!this.seleniumArgs.port && config.port && config.usePortInStandalone) {
             this.seleniumArgs.seleniumArgs = ['-port', config.port]
         }
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -13,14 +13,7 @@ class SeleniumStandaloneLauncher {
     }
 
     onPrepare (config) {
-        this.seleniumArgs = config.seleniumArgs || {}
-        this.seleniumInstallArgs = config.seleniumInstallArgs || {}
-        this.seleniumLogs = config.seleniumLogs
-        this.logToStdout = config.logToStdout
-
-        if (!this.seleniumArgs.port && config.port && config.usePortInStandalone) {
-            this.seleniumArgs.seleniumArgs = ['-port', config.port]
-        }
+        this._getConfig(config)
 
         return this._installSeleniumDependencies(this.seleniumInstallArgs).then(() => new Promise((resolve, reject) => Selenium.start(this.seleniumArgs, (err, process) => {
             if (err) {
@@ -39,6 +32,22 @@ class SeleniumStandaloneLauncher {
     onComplete () {
         if (this.process) {
             this.process.kill()
+        }
+    }
+
+    _getConfig (config) {
+        this.seleniumArgs = config.seleniumArgs || {}
+        this.seleniumInstallArgs = config.seleniumInstallArgs || {}
+        this.seleniumLogs = config.seleniumLogs
+        this.logToStdout = config.logToStdout
+
+        if (config.port && config.usePortInStandalone) {
+            if (this.seleniumArgs.seleniumArgs === undefined) {
+                this.seleniumArgs.seleniumArgs = []
+            }
+            if (!this.seleniumArgs.seleniumArgs.includes('-port')) {
+                this.seleniumArgs.seleniumArgs.push('-port', config.port)
+            }
         }
     }
 

--- a/test/unit/launcher/launcher.spec.js
+++ b/test/unit/launcher/launcher.spec.js
@@ -35,7 +35,7 @@ describe('getFilePath', function () {
 		assert.ok(portIndex >= 0 && launch.seleniumArgs.seleniumArgs[portIndex + 1] === 4444)
 	})
 
-	it('should add custom port to seleniumArgs (flag not specified)', function() {
+	it('should not add custom port to seleniumArgs (flag not specified)', function() {
 		const config = {
 			port: 4441,
 			seleniumArgs: {}, 

--- a/test/unit/launcher/launcher.spec.js
+++ b/test/unit/launcher/launcher.spec.js
@@ -1,0 +1,51 @@
+import launcher from '../../../lib/launcher'
+import path from 'path'
+import assert from 'assert'
+
+describe('getFilePath', function () {
+	it('should add custom port to seleniumArgs', function() {
+		const config = {
+			port: 4441,
+			usePortInStandalone: true,
+			seleniumArgs: {}, 
+			seleniumLogs: './logs',
+			services: ['selenium-standalone']
+		}
+		const launch = new launcher()
+		launch._getConfig(config)
+
+		const portIndex = launch.seleniumArgs.seleniumArgs.indexOf('-port')
+		assert.ok(portIndex >= 0 && launch.seleniumArgs.seleniumArgs[portIndex + 1] === 4441)
+	})
+
+	it('should not override custom port already in seleniumArgs', function() {
+		const config = {
+			port: 4441,
+			usePortInStandalone: true,
+			seleniumArgs: {
+				seleniumArgs: ['-port', 4444]
+			}, 
+			seleniumLogs: './logs',
+			services: ['selenium-standalone']
+		}
+		const launch = new launcher()
+		launch._getConfig(config)
+
+		const portIndex = launch.seleniumArgs.seleniumArgs.indexOf('-port')
+		assert.ok(portIndex >= 0 && launch.seleniumArgs.seleniumArgs[portIndex + 1] === 4444)
+	})
+
+	it('should add custom port to seleniumArgs (flag not specified)', function() {
+		const config = {
+			port: 4441,
+			seleniumArgs: {}, 
+			seleniumLogs: './logs',
+			services: ['selenium-standalone']
+		}
+		const launch = new launcher()
+		launch._getConfig(config)
+		console.log(launch.seleniumArgs)
+
+		assert.ok(launch.seleniumArgs.seleniumArgs === undefined)
+	})
+})

--- a/test/unit/launcher/launcher.spec.js
+++ b/test/unit/launcher/launcher.spec.js
@@ -6,7 +6,6 @@ describe('getFilePath', function () {
 	it('should add custom port to seleniumArgs', function() {
 		const config = {
 			port: 4441,
-			usePortInStandalone: true,
 			seleniumArgs: {}, 
 			seleniumLogs: './logs',
 			services: ['selenium-standalone']
@@ -21,7 +20,6 @@ describe('getFilePath', function () {
 	it('should not override custom port already in seleniumArgs', function() {
 		const config = {
 			port: 4441,
-			usePortInStandalone: true,
 			seleniumArgs: {
 				seleniumArgs: ['-port', 4444]
 			}, 
@@ -33,19 +31,5 @@ describe('getFilePath', function () {
 
 		const portIndex = launch.seleniumArgs.seleniumArgs.indexOf('-port')
 		assert.ok(portIndex >= 0 && launch.seleniumArgs.seleniumArgs[portIndex + 1] === 4444)
-	})
-
-	it('should not add custom port to seleniumArgs (flag not specified)', function() {
-		const config = {
-			port: 4441,
-			seleniumArgs: {}, 
-			seleniumLogs: './logs',
-			services: ['selenium-standalone']
-		}
-		const launch = new launcher()
-		launch._getConfig(config)
-		console.log(launch.seleniumArgs)
-
-		assert.ok(launch.seleniumArgs.seleniumArgs === undefined)
 	})
 })


### PR DESCRIPTION
The other pull request was on the wrong branch :)

This change would allow wdio-selenium-standalone-service to detect a custom port defined in the wdio config file for the Selenium standalone server. This would be helpful for people running multiple instances of a test suite concurrently on the same machine, allowing them to pass in the desired port number only to the wdio command, and not have to also specify it in seleniumArgs in the config file. A custom port for the standalone server is necessary to prevent conflicts between different testing instances.