### PR TITLE
Update selenium-standalone to 6.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/webdriverio/wdio-selenium-standalone-service#readme",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "selenium-standalone": "^6.13.0"
+    "selenium-standalone": "^6.15.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
To have the latest upstream bugfixes.
I have a problem with hash-only navigation, not sure if this change will resolve it, but anyways I think it needs to be bumped when there's an upstream release.