### PR TITLE
Updated selenium-standalone package

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "grunt-eslint": "^18.0.0",
     "load-grunt-tasks": "^3.4.1",
     "mocha": "^2.5.3",
-    "wdio-mocha-framework": "^0.2.12",
-    "webdriverio": "^4.0.7"
+    "wdio-mocha-framework": "^0.6.4",
+    "webdriverio": "^4.14.0"
   },
   "contributors": [
     "Christian Bromann <github@christian-bromann.com>",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/webdriverio/wdio-selenium-standalone-service#readme",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "selenium-standalone": "^6.13.0"
+    "selenium-standalone": "^6.15.4"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
Updated old packages:

-  `selenium-standalone` => version`6.15.4`
https://www.npmjs.com/package/selenium-standalone

- `wdio-mocha-framework` => version `0.6.4`
https://www.npmjs.com/package/wdio-mocha-framework

- `webdriverio` => version `4.14.0`
https://www.npmjs.com/package/webdriverio

The latest versions fix some compatibility issues with Node 10 & RHEL7
